### PR TITLE
Add operationId to each action in the schema

### DIFF
--- a/ActionSchema.json
+++ b/ActionSchema.json
@@ -9,6 +9,7 @@
     "/companyResearch": {
       "post": {
         "description": "Get financial data for a company by name",
+        "operationId": "companyResearch",
         "parameters": [
           {
             "name": "name",
@@ -37,6 +38,7 @@
     "/createPortfolio": {
       "post": {
         "description": "Create a company portfolio of top profit earners by specifying number of companies and industry",
+        "operationId": "createPortfolio",
         "parameters": [
           {
             "name": "numCompanies",
@@ -75,6 +77,7 @@
     "/sendEmail": {
       "post": {
         "description": "Send an email with FOMC search summary and created portfolio",
+        "operationId": "sendEmail",
         "parameters": [
           {
             "name": "emailAddress",


### PR DESCRIPTION
When following the workshop instructions I got an error saying `operationId` is missing from the schema. ([agents-api-schema docs](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-api-schema.html))